### PR TITLE
feat: implement keychain store to save api tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,4 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
-
-# Configuration
-ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Config.swift
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 This app shortens long URLs using multiple providers.
 
 # Configuration
-Create a `Config.swift` file under `ShortURLBuilderProvider/Sources/ShortURLBuilderProvider` to define the required token/API key.
+Use `KeyChain` to store the API keys for the URL shortening services.
+You can see the "key" icon in the top right corner of the app. Click on it to add your API keys.
 
-```swift
-enum Config {
-    static let bitlyToken = "YOUR_TOKEN"
-
-    static let cuttlyApiKey = "YOUR_API_KEY"
-}
-```
+At the moment, the app supports the following services:
+  - Bitly
+  - Cuttly

--- a/ShortURLBuilder/ShortenLinkBuilderApp.swift
+++ b/ShortURLBuilder/ShortenLinkBuilderApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import ShortURLBuilderProvider
 
 @main
 struct ShortenLinkBuilderApp: App {

--- a/ShortURLBuilder/Views/ContentView.swift
+++ b/ShortURLBuilder/Views/ContentView.swift
@@ -5,16 +5,17 @@
 //  Created by Ching-Wen Terry TAN on 09/08/2024.
 //
 
-import SwiftUI
-import SwiftData
 import ShortURLBuilderProvider
+import SwiftData
+import SwiftUI
 
 @MainActor
 struct ContentView: View {
     var providers = Provider.allCases
-
+    
     @State var selected: ServiceModel?
-
+    @State private var showingCredentials = false
+    @StateObject private var credentialsManager = CredentialsManager.shared
     var body: some View {
         NavigationView {
             List {
@@ -29,6 +30,15 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("Shorten your link")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingCredentials = true
+                    } label: {
+                        Image(systemName: "key.fill")
+                    }
+                }
+            }
         }
         .sheet(item: $selected) {
             selected = nil
@@ -37,9 +47,9 @@ struct ContentView: View {
                 .presentationDetents([.medium])
                 .interactiveDismissDisabled()
         }
+        .sheet(isPresented: $showingCredentials) {
+            CredentialsView()
+        }
+        .environmentObject(credentialsManager)
     }
-}
-
-#Preview {
-    ContentView()
 }

--- a/ShortURLBuilderAction/ShortURLBuilderAction.entitlements
+++ b/ShortURLBuilderAction/ShortURLBuilderAction.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array/>
+</dict>
+</plist>

--- a/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Config.swift
+++ b/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Config.swift
@@ -1,0 +1,19 @@
+enum Config {
+    // static let appGroup = "group.shortUrlDev.app.identifier" 
+    
+    static var bitlyToken: String {
+        KeychainService.retrieve(forKey: CredentialType.bitlyToken.rawValue) ?? ""
+    }
+
+    static var cuttlyApiKey: String {
+        KeychainService.retrieve(forKey: CredentialType.cuttlyApiKey.rawValue) ?? ""
+    }
+
+    static func saveBitlyToken(_ token: String) {
+        _ = KeychainService.save(token, forKey: CredentialType.bitlyToken.rawValue)
+    }
+
+    static func saveCuttlyKey(_ key: String) {
+        _ = KeychainService.save(key, forKey: CredentialType.cuttlyApiKey.rawValue)
+    }
+}

--- a/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsManager.swift
+++ b/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsManager.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum CredentialType: String, CaseIterable {
+    case bitlyToken = "BitlyAPIToken"
+    case cuttlyApiKey = "CuttlyApiToken"
+
+    public var displayName: String {
+        switch self {
+        case .bitlyToken:
+            return "Bitly API Token"
+        case .cuttlyApiKey:
+            return "Cuttly API Token"
+        }
+    }
+}
+
+@MainActor
+public final class CredentialsManager: ObservableObject {
+    public static let shared = CredentialsManager()
+    private init() {}
+
+    public func save(_ value: String, for type: CredentialType) {
+        guard !value.isEmpty else { return }
+        _ = KeychainService.save(value, forKey: type.rawValue)
+    }
+
+    public func retrieve(for type: CredentialType) -> String {
+        KeychainService.retrieve(forKey: type.rawValue) ?? ""
+    }
+
+    public func delete(type: CredentialType) {
+        _ = KeychainService.delete(forKey: type.rawValue)
+    }
+
+}

--- a/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsView.swift
+++ b/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+public struct CredentialsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var credentialsManager: CredentialsManager
+    @State private var bitlyToken: String = ""
+    @State private var cuttlyKey: String = ""
+    @State private var isEditingBitly = false
+    @State private var isEditingCuttly = false
+    @State private var hasBitlyToken = false
+    @State private var hasCuttlyKey = false
+    
+    private let placeholderDots = "••••••••••"
+    
+    public init() {}
+    
+    public var body: some View {
+        NavigationView {
+            List {
+                Section("Bitly") {
+                    ZStack(alignment: .leading) {
+                        if !isEditingBitly && hasBitlyToken {
+                            Text(placeholderDots)
+                        }
+                        SecureField("Enter Bitly Token", text: $bitlyToken)
+                            .opacity(isEditingBitly || !hasBitlyToken ? 1 : 0)
+                            .onTapGesture {
+                                isEditingBitly = true
+                            }
+                    }
+                    
+                    if hasBitlyToken {
+                        Button(role: .destructive) {
+                            credentialsManager.delete(type: .bitlyToken)
+                            bitlyToken = ""
+                            isEditingBitly = false
+                            hasBitlyToken = false
+                        } label: {
+                            Text("Delete Bitly Token")
+                        }
+                    }
+                }
+                
+                Section("Cuttly") {
+                    ZStack(alignment: .leading) {
+                        if !isEditingCuttly && hasCuttlyKey {
+                            Text(placeholderDots)
+                        }
+                        SecureField("Enter Cuttly API Key", text: $cuttlyKey)
+                            .opacity(isEditingCuttly || !hasCuttlyKey ? 1 : 0)
+                            .onTapGesture {
+                                isEditingCuttly = true
+                            }
+                    }
+                    
+                    if hasCuttlyKey {
+                        Button(role: .destructive) {
+                            credentialsManager.delete(type: .cuttlyApiKey)
+                            cuttlyKey = ""
+                            isEditingCuttly = false
+                            hasCuttlyKey = false
+                        } label: {
+                            Text("Delete Cuttly API Key")
+                        }
+                    }
+                }
+            }
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .navigationTitle("API Credentials")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        saveCredentials()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            bitlyToken = credentialsManager.retrieve(for: .bitlyToken)
+            cuttlyKey = credentialsManager.retrieve(for: .cuttlyApiKey)
+            hasBitlyToken = !credentialsManager.retrieve(for: .bitlyToken).isEmpty
+            hasCuttlyKey = !credentialsManager.retrieve(for: .cuttlyApiKey).isEmpty
+        }
+    }
+    
+    private func saveCredentials() {
+        if !bitlyToken.isEmpty {
+            credentialsManager.save(bitlyToken, for: .bitlyToken)
+            hasBitlyToken = true
+        }
+        if !cuttlyKey.isEmpty {
+            credentialsManager.save(cuttlyKey, for: .cuttlyApiKey)
+            hasCuttlyKey = true
+        }
+        dismiss()
+    }
+}

--- a/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Services/KeyChainService.swift
+++ b/ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Services/KeyChainService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Security
+
+enum KeychainService {
+    static func save(_ value: String, forKey key: String) -> Bool {
+        print("🔑 Saving to Keychain - Key: \(key)")
+        guard let data = value.data(using: .utf8) else {
+            print("❌ Failed to convert value to data")
+            return false
+        }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data,
+//            kSecAttrAccessGroup: Config.appGroup,
+        ]
+
+        // First try to delete any existing value
+        SecItemDelete(query as CFDictionary)
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        let success = status == errSecSuccess
+        print("🔑 Save status: \(success ? "Success ✅" : "Failed ❌") - Status: \(status)")
+        return success
+    }
+
+    static func retrieve(forKey key: String) -> String? {
+        print("🔍 Retrieving from Keychain - Key: \(key)")
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+//            kSecAttrAccessGroup: Config.appGroup,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess else {
+            print("❌ Retrieval failed with status: \(status)")
+            return nil
+        }
+        if let data = result as? Data, let value = String(data: data, encoding: .utf8) {
+            print("✅ Retrieved value successfully (length: \(value.count))")
+            return value
+        }
+        print("❌ Failed to convert data to string")
+        return nil
+    }
+
+    static func delete(forKey key: String) -> Bool {
+        print("🗑 Deleting from Keychain - Key: \(key)")
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+//            kSecAttrAccessGroup: Config.appGroup,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        let success = status == errSecSuccess
+        print("🗑 Delete status: \(success ? "Success ✅" : "Failed ❌") - Status: \(status)")
+        return success
+    }
+}

--- a/ShortURLNetwork/Sources/ShortURLNetwork/ShortenLinkNetworker.swift
+++ b/ShortURLNetwork/Sources/ShortURLNetwork/ShortenLinkNetworker.swift
@@ -17,8 +17,8 @@ public protocol ShortenLinkNetworkerProtocol {
     ) async throws -> T
 }
 
-public extension ShortenLinkNetworkerProtocol {
-    func requestDecodable<T: Decodable>(
+extension ShortenLinkNetworkerProtocol {
+    public func requestDecodable<T: Decodable>(
         _ type: T.Type,
         endpoint: any BaseEndpoint
     ) async throws -> T {
@@ -35,7 +35,7 @@ public actor ShortenLinkNetworker: ShortenLinkNetworkerProtocol {
 
     public func requestData(_ request: URLRequest) async throws -> Data {
         let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse, 200 ..< 300 ~= httpResponse.statusCode else {
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
             throw URLError(.badServerResponse)
         }
         return data


### PR DESCRIPTION
This pull request introduces several significant changes to improve the handling of API credentials and the overall user experience for managing them. The most important changes include the addition of a credentials manager, updates to the configuration process, and enhancements to the user interface for entering and storing API keys.

### Credential Management Enhancements:

* [`ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Config.swift`](diffhunk://#diff-bc2ed710c87dbd48afc1ba677b3f3d9e482fe3597757ed5e126eebcc71c9939fR1-R19): Updated to use `KeychainService` for storing and retrieving API keys instead of hardcoding them.
* [`ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsManager.swift`](diffhunk://#diff-c44b7434e99ce2b96762ee5aa38143e6b24f4ef9d30610c7a6db6cf0b2f4cf68R1-R35): Introduced a `CredentialsManager` class to handle saving, retrieving, and deleting API credentials using `KeychainService`.
* [`ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Services/KeyChainService.swift`](diffhunk://#diff-2a71917befe79e2d921ca316394cbf67f6f87e25f08fa206f1f6caa459d7f946R1-R66): Added a `KeychainService` to securely save, retrieve, and delete credentials.

### User Interface Enhancements:

* [`ShortURLBuilder/Views/ContentView.swift`](diffhunk://#diff-22d3c7e1c67d1d7d8738b2a46c421fdda2823e1896d3dd78c793a9f6da1fc3d0R33-R41): Added a toolbar button to open a new `CredentialsView` for managing API keys and integrated the `CredentialsManager` into the environment. [[1]](diffhunk://#diff-22d3c7e1c67d1d7d8738b2a46c421fdda2823e1896d3dd78c793a9f6da1fc3d0R33-R41) [[2]](diffhunk://#diff-22d3c7e1c67d1d7d8738b2a46c421fdda2823e1896d3dd78c793a9f6da1fc3d0R50-L44)
* [`ShortURLBuilderProvider/Sources/ShortURLBuilderProvider/Credentials/CredentialsView.swift`](diffhunk://#diff-5af422c53502e7669a7c9a6bf3574f0434f513c0f46d3864e5a4649b117e1ca5R1-R116): Created a new view for users to enter and manage their API credentials, with sections for Bitly and Cuttly tokens.

### Configuration Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R10): Updated configuration instructions to use `KeyChain` for storing API keys and removed the previous method of hardcoding them in a `Config.swift` file.